### PR TITLE
Upgrade rtlcss to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "babel-runtime": "~6.25.0",
-    "rtlcss": "^2.2.1"
+    "rtlcss": "^3.5.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Because of a security vulnerability in the rtlcss dependency, this package needs to be updated.